### PR TITLE
Fix Dudu and AE VN resources

### DIFF
--- a/public/novels/ae/en-US/game.css
+++ b/public/novels/ae/en-US/game.css
@@ -108,7 +108,7 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/background/bg.jpg)
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/background/bg.jpg)
     center / auto 100% no-repeat;
   z-index: 520;
   display: none;
@@ -120,7 +120,7 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/background/CG1.jpg)
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/background/CG1.jpg)
     center / auto 100% no-repeat;
   z-index: 520;
   display: none;
@@ -132,32 +132,32 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/dark.png)
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/dark.png)
     center / auto 100% no-repeat;
 }
 
 .catalog-content-1A {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/A.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/A.png);
 }
 
 .catalog-content-2Ab {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/Ab.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/Ab.png);
 }
 
 .catalog-content-3Abc {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/Abc.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/Abc.png);
 }
 
 .catalog-content-2Ba {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/Ba.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/Ba.png);
 }
 
 .catalog-content-3Bac {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/Bac.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/Bac.png);
 }
 
 .catalog-content-3Cab {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/Cab.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/Cab.png);
 }
 
 #catalog-content-0 {
@@ -190,7 +190,7 @@ p {
   top: 6rem;
   height: 2rem;
   right: 3rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/go.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/go.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -226,7 +226,7 @@ p {
   top: 1.55rem;
   height: 1.5rem;
   left: 7.75rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_1_on.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_1_on.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -238,7 +238,7 @@ p {
   top: 1.35rem;
   height: 1.5rem;
   left: 7.75rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_1_off.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_1_off.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -251,7 +251,7 @@ p {
   top: 1.55rem;
   height: 1.5rem;
   left: 14.3rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_2_on.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_2_on.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -263,7 +263,7 @@ p {
   top: 1.35rem;
   height: 1.5rem;
   left: 14.3rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_2_off.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_2_off.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -276,7 +276,7 @@ p {
   top: 1.55rem;
   height: 1.5rem;
   left: 20.85rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_3_on.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_3_on.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -288,7 +288,7 @@ p {
   top: 1.35rem;
   height: 1.5rem;
   left: 20.85rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_3_off.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_3_off.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -301,7 +301,7 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/portraitBg.jpg)
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/portraitBg.jpg)
     center / auto 100% no-repeat;
   z-index: 520;
   display: none;
@@ -313,7 +313,7 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/listBG.jpg)
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/listBG.jpg)
     center / auto 100% no-repeat;
   z-index: 1200;
   display: none;
@@ -325,7 +325,7 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/background/bg.jpg)
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/background/bg.jpg)
     center / auto 100% no-repeat;
   z-index: 1300;
   display: none;
@@ -356,7 +356,7 @@ p {
   width: 28.55rem;
   left: 0;
   bottom: 0;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/barBottom.png);
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/barBottom.png);
   background-size: 28.55rem 2.1rem;
   background-position: left;
   background-repeat: no-repeat;
@@ -380,7 +380,7 @@ p {
   height: 2.1rem;
   left: 0;
   bottom: 0;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/barTop.png);
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/barTop.png);
   background-size: 28.55rem 2.1rem;
   background-position: left;
   background-repeat: no-repeat;
@@ -393,7 +393,7 @@ p {
   bottom: -1.75rem;
   height: 4.5rem;
   width: 39.1rem;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/barFrame.png);
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/barFrame.png);
   background-size: 39.1rem 4.5rem;
   background-position: left;
   background-repeat: no-repeat;
@@ -406,7 +406,7 @@ p {
   width: 2.6rem;
   left: 0;
   bottom: -0.375rem;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/barIcon.png);
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/barIcon.png);
   background-size: 2.6rem 2.85rem;
   background-position: left;
   background-repeat: no-repeat;
@@ -420,7 +420,7 @@ p {
   width: 5.9rem;
   right: 0.75rem;
   bottom: 0.65rem;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/details.png)
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/details.png)
     center / auto 100% no-repeat;
   cursor: pointer;
 }
@@ -713,7 +713,7 @@ p {
   top: 0;
   right: 0;
   z-index: 810;
-  background: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/close.png');
+  background: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/close.png');
   background-size: 100% 100%;
   background-position: center;
   cursor: pointer;
@@ -741,7 +741,7 @@ p {
   bottom: 6rem;
   right: 0;
   z-index: 810;
-  background: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/remark.png');
+  background: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/remark.png');
   background-size: 100% 100%;
   background-position: center;
 }
@@ -754,7 +754,7 @@ p {
   top: 0;
   right: 0;
   z-index: 810;
-  background: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/close.png');
+  background: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/close.png');
   background-size: 100% 100%;
   background-position: center;
   cursor: pointer;
@@ -768,7 +768,7 @@ p {
   top: 0;
   right: 0;
   z-index: 810;
-  background: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/exit.png');
+  background: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/exit.png');
   background-size: 100% 100%;
   background-position: center;
   cursor: pointer;
@@ -791,7 +791,7 @@ p {
   top: 0;
   left: 0;
   z-index: 810;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/save.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/save.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -805,7 +805,7 @@ p {
   top: 0;
   left: 6.4rem;
   z-index: 810;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/load.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/load.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -827,7 +827,7 @@ p {
   height: 100%;
   bottom: 0;
   left: 6.4rem;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/auto.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/auto.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -835,7 +835,7 @@ p {
 }
 
 .dialog-btn-autoplay-on {
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/auto_1.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/auto_1.png');
 }
 
 .dialog-btn-history {
@@ -844,7 +844,7 @@ p {
   height: 100%;
   top: 0;
   right: 0;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/log.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/log.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -857,7 +857,7 @@ p {
   height: 100%;
   top: 0;
   left: 0;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/skip.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/skip.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -865,7 +865,7 @@ p {
 }
 
 .dialog-btn-skip-on {
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/skip_1.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/skip_1.png');
 }
 
 .menuscene {
@@ -875,7 +875,7 @@ p {
   top: 0px;
   left: 0px;
   z-index: 400;
-  background: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/menu/back.jpg')
+  background: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/menu/back.jpg')
     black no-repeat;
   background-size: 100% auto;
   background-position: center;
@@ -886,7 +886,7 @@ p {
   width: 100%;
   height: 100%;
   z-index: 0;
-  background: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/menu/fg.png');
+  background: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/menu/fg.png');
   background-size: auto 100%;
 }
 
@@ -898,7 +898,7 @@ p {
       top: 0px;
       left: 0px;
       z-index: 400;
-      background: url("https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/menu/back_pad.jpg");
+      background: url("https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/menu/back_pad.jpg");
       background-size: 100% 100%;
       background-position: center;
   }*/
@@ -1458,7 +1458,7 @@ p {
   width: /*90%*/ 42rem;
   height: /*25%*/ 7rem;
   z-index: 210;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/dialog.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/dialog.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -1468,7 +1468,7 @@ p {
 
 .dialog_article {
   height: 21rem;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/dialogBig.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/dialogBig.png');
 }
 
 .history {
@@ -1478,7 +1478,7 @@ p {
   width: 42rem;
   height: 21rem;
   z-index: 250;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/dialogBig.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/dialogBig.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -1492,7 +1492,7 @@ p {
   width: 42rem;
   height: 21rem;
   z-index: 250;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/dialogBig.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/dialogBig.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -1627,17 +1627,17 @@ p {
 
 .dialog-chara-line.dialog-chara-left {
   width: 1.14rem;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/Label-L.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/Label-L.png');
 }
 
 .dialog-chara-line.dialog-chara-center {
   background-repeat: repeat;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/Label-M.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/Label-M.png');
 }
 
 .dialog-chara-line.dialog-chara-right {
   width: 2.4rem;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/Label-R.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/Label-R.png');
 }
 
 .dialog-chara-padding {
@@ -1835,19 +1835,19 @@ p {
 }
 
 .high {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/expression/high.gif);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/expression/high.gif);
 }
 
 .low {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/expression/low.gif);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/expression/low.gif);
 }
 
 .middle {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/expression/middle.gif);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/expression/middle.gif);
 }
 
 .super {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/expression/super.gif);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/expression/super.gif);
 }
 
 ul li {
@@ -1883,27 +1883,27 @@ ul li {
 }
 
 #pagenum-1 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/left.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/left.png);
 }
 
 #pagenum-2 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/right.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/right.png);
 }
 
 #pagenum-5 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/leftPage.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/leftPage.png);
 }
 
 #pagenum-6 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/rightPage.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/rightPage.png);
 }
 
 #pagenum-7 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/left.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/left.png);
 }
 
 #pagenum-8 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/right.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/right.png);
 }
 
 .cg-frame {
@@ -1925,7 +1925,7 @@ ul li {
   background-size: auto 88%;
   background-position: center;
   display: inline-block;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/common/cgclose.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/common/cgclose.png);
 }
 
 .showCgOrigin {

--- a/public/novels/ae/en-US/game.js
+++ b/public/novels/ae/en-US/game.js
@@ -1,4 +1,4 @@
-var base_url = 'https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy'
+var base_url = 'https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy'
 base_url = resPath
 var now_galgame_tag = '_2017_anti_entropy_now_galgame'
 var now_scene_tag = '_2017_anti_entropy_now_scene'

--- a/public/novels/ae/en-US/index.html
+++ b/public/novels/ae/en-US/index.html
@@ -19,12 +19,12 @@
       content="black-translucent"
     />
     <link
-      href="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/css/common.css?v=20210817"
+      href="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/css/common.css?v=20210817"
       rel="stylesheet"
       type="text/css"
     />
     <link
-      href="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/css/css3_animation.css?v=20210817"
+      href="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/css/css3_animation.css?v=20210817"
       rel="stylesheet"
       type="text/css"
     />
@@ -64,14 +64,14 @@
     <div class="wrk">
       <img
         class="wrk-i"
-        src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/common/horizon_hint.png"
+        src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/common/horizon_hint.png"
       />
     </div>
     <table id="loading">
       <tr>
         <td>
           <img
-            src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/common/loading.gif"
+            src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/common/loading.gif"
           />
         </td>
       </tr>
@@ -82,7 +82,7 @@
         <audio
           class="bgm"
           id="indexbgm"
-          src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/sound/themeEin.mp3"
+          src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/sound/themeEin.mp3"
           loop="loop"
           controls="controls"
         ></audio>
@@ -266,25 +266,25 @@
     </div>
     <script>
       var cssPath =
-        'https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN'
+        'https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN'
       var jsPath =
-        'https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN'
+        'https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN'
       var resPath =
-        'https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN'
+        'https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN'
       var xmlPath = '/novels/ae/en-US/xml/'
       var lang = 'ko'
     </script>
     <script
       type="text/javascript"
-      src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/tips/game_tips.js?v=20210817"
+      src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/tips/game_tips.js?v=20210817"
     ></script>
     <script
       type="text/javascript"
-      src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/js/jquery-1.11.1.min.js?v=20210817"
+      src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/js/jquery-1.11.1.min.js?v=20210817"
     ></script>
     <script
       type="text/javascript"
-      src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/js/xmlhttp.js?v=20210817"
+      src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/js/xmlhttp.js?v=20210817"
     ></script>
     <script type="text/javascript" src="/novels/ae/en-US/game.js?v=20210817"></script>
   </body>

--- a/public/novels/ae/ko-KR/game.css
+++ b/public/novels/ae/ko-KR/game.css
@@ -109,7 +109,7 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/background/bg.jpg) center /auto 100% no-repeat;
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/background/bg.jpg) center /auto 100% no-repeat;
   z-index: 520;
   display: none;
 }
@@ -120,7 +120,7 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/background/CG1.jpg) center /auto 100% no-repeat;
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/background/CG1.jpg) center /auto 100% no-repeat;
   z-index: 520;
   display: none;
 }
@@ -131,31 +131,31 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/dark.png) center /auto 100% no-repeat;
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/dark.png) center /auto 100% no-repeat;
 }
 
 .catalog-content-1A {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/A.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/A.png);
 }
 
 .catalog-content-2Ab {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/Ab.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/Ab.png);
 }
 
 .catalog-content-3Abc {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/Abc.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/Abc.png);
 }
 
 .catalog-content-2Ba {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/Ba.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/Ba.png);
 }
 
 .catalog-content-3Bac {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/Bac.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/Bac.png);
 }
 
 .catalog-content-3Cab {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/Cab.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/Cab.png);
 }
 
 #catalog-content-0 {
@@ -188,7 +188,7 @@ p {
   top: 6rem;
   height: 2rem;
   right: 3rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/go.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/go.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -224,7 +224,7 @@ p {
   top: 1.55rem;
   height: 1.5rem;
   left: 7.75rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_1_on.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_1_on.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -236,7 +236,7 @@ p {
   top: 1.35rem;
   height: 1.5rem;
   left: 7.75rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_1_off.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_1_off.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -249,7 +249,7 @@ p {
   top: 1.55rem;
   height: 1.5rem;
   left: 14.3rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_2_on.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_2_on.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -261,7 +261,7 @@ p {
   top: 1.35rem;
   height: 1.5rem;
   left: 14.3rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_2_off.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_2_off.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -274,7 +274,7 @@ p {
   top: 1.55rem;
   height: 1.5rem;
   left: 20.85rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_3_on.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_3_on.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -286,7 +286,7 @@ p {
   top: 1.35rem;
   height: 1.5rem;
   left: 20.85rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_3_off.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/catalog/label_3_off.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -299,7 +299,7 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/portraitBg.jpg) center /auto 100% no-repeat;
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/portraitBg.jpg) center /auto 100% no-repeat;
   z-index: 520;
   display: none;
 }
@@ -310,7 +310,7 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/listBG.jpg) center /auto 100% no-repeat;
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/listBG.jpg) center /auto 100% no-repeat;
   z-index: 1200;
   display: none;
 }
@@ -321,7 +321,7 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/background/bg.jpg) center /auto 100% no-repeat;
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/background/bg.jpg) center /auto 100% no-repeat;
   z-index: 1300;
   display: none;
 }
@@ -351,7 +351,7 @@ p {
   width: 28.55rem;
   left: 0;
   bottom: 0;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/barBottom.png);
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/barBottom.png);
   background-size: 28.55rem 2.1rem;
   background-position: left;
   background-repeat: no-repeat;
@@ -375,7 +375,7 @@ p {
   height: 2.1rem;
   left: 0;
   bottom: 0;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/barTop.png);
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/barTop.png);
   background-size: 28.55rem 2.1rem;
   background-position: left;
   background-repeat: no-repeat;
@@ -388,7 +388,7 @@ p {
   bottom: -1.75rem;
   height: 4.5rem;
   width: 39.1rem;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/barFrame.png);
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/barFrame.png);
   background-size: 39.1rem 4.5rem;
   background-position: left;
   background-repeat: no-repeat;
@@ -401,7 +401,7 @@ p {
   width: 2.6rem;
   left: 0;
   bottom: -0.375rem;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/barIcon.png);
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/barIcon.png);
   background-size: 2.6rem 2.85rem;
   background-position: left;
   background-repeat: no-repeat;
@@ -415,7 +415,7 @@ p {
   width: 5.9rem;
   right: 0.75rem;
   bottom: 0.65rem;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/details.png) center /auto 100% no-repeat;
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/details.png) center /auto 100% no-repeat;
   cursor: pointer;
 }
 
@@ -707,7 +707,7 @@ p {
   top: 0;
   right: 0;
   z-index: 810;
-  background: url("https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/close.png");
+  background: url("https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/close.png");
   background-size: 100% 100%;
   background-position: center;
   cursor: pointer;
@@ -735,7 +735,7 @@ p {
   bottom: 6rem;
   right: 0;
   z-index: 810;
-  background: url("https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/remark.png");
+  background: url("https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/remark.png");
   background-size: 100% 100%;
   background-position: center;
 }
@@ -748,7 +748,7 @@ p {
   top: 0;
   right: 0;
   z-index: 810;
-  background: url("https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/close.png");
+  background: url("https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/close.png");
   background-size: 100% 100%;
   background-position: center;
   cursor: pointer;
@@ -762,7 +762,7 @@ p {
   top: 0;
   right: 0;
   z-index: 810;
-  background: url("https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/exit.png");
+  background: url("https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/exit.png");
   background-size: 100% 100%;
   background-position: center;
   cursor: pointer;
@@ -788,7 +788,7 @@ p {
   top: 0;
   left: 0;
   z-index: 810;
-  background-image: url("https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/save.png");
+  background-image: url("https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/save.png");
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -803,7 +803,7 @@ p {
   top: 0;
   left: 6.4rem;
   z-index: 810;
-  background-image: url("https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/load.png");
+  background-image: url("https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/load.png");
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -825,7 +825,7 @@ p {
   height: 100%;
   bottom: 0;
   left: 6.4rem;
-  background-image: url("https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/auto.png");
+  background-image: url("https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/auto.png");
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -833,7 +833,7 @@ p {
 }
 
 .dialog-btn-autoplay-on {
-  background-image: url("https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/auto_1.png");
+  background-image: url("https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/auto_1.png");
 }
 
 .dialog-btn-history {
@@ -842,7 +842,7 @@ p {
   height: 100%;
   top: 0;
   right: 0;
-  background-image: url("https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/log.png");
+  background-image: url("https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/log.png");
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -855,7 +855,7 @@ p {
   height: 100%;
   top: 0;
   left: 0;
-  background-image: url("https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/skip.png");
+  background-image: url("https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/skip.png");
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -863,7 +863,7 @@ p {
 }
 
 .dialog-btn-skip-on {
-  background-image: url("https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/skip_1.png");
+  background-image: url("https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/skip_1.png");
 }
 
 .menuscene {
@@ -873,7 +873,7 @@ p {
   top: 0px;
   left: 0px;
   z-index: 400;
-  background: url("https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/menu/back.jpg") black no-repeat;
+  background: url("https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/menu/back.jpg") black no-repeat;
   background-size: 100% auto;
   background-position: center;
 }
@@ -883,7 +883,7 @@ p {
   width: 100%;
   height: 100%;
   z-index: 0;
-  background: url("https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/menu/fg.png");
+  background: url("https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/menu/fg.png");
   background-size: auto 100%;
 }
 
@@ -895,7 +895,7 @@ p {
       top: 0px;
       left: 0px;
       z-index: 400;
-      background: url("https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/menu/back_pad.jpg");
+      background: url("https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/menu/back_pad.jpg");
       background-size: 100% 100%;
       background-position: center;
   }*/
@@ -1480,7 +1480,7 @@ p {
   height: /*25%*/
   7rem;
   z-index: 210;
-  background-image: url("https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/dialog.png");
+  background-image: url("https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/dialog.png");
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -1490,7 +1490,7 @@ p {
 
 .dialog_article {
   height: 21rem;
-  background-image: url("https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/dialogBig.png");
+  background-image: url("https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/dialogBig.png");
 }
 
 .history {
@@ -1500,7 +1500,7 @@ p {
   width: 42rem;
   height: 21rem;
   z-index: 250;
-  background-image: url("https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/dialogBig.png");
+  background-image: url("https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/dialogBig.png");
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -1514,7 +1514,7 @@ p {
   width: 42rem;
   height: 21rem;
   z-index: 250;
-  background-image: url("https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/dialogBig.png");
+  background-image: url("https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/dialogBig.png");
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -1652,17 +1652,17 @@ p {
 
 .dialog-chara-line.dialog-chara-left {
   width: 1.14rem;
-  background-image: url("https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/Label-L.png");
+  background-image: url("https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/Label-L.png");
 }
 
 .dialog-chara-line.dialog-chara-center {
   background-repeat: repeat;
-  background-image: url("https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/Label-M.png");
+  background-image: url("https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/Label-M.png");
 }
 
 .dialog-chara-line.dialog-chara-right {
   width: 2.4rem;
-  background-image: url("https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/Label-R.png");
+  background-image: url("https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/Label-R.png");
 }
 
 .dialog-chara-padding {
@@ -1860,19 +1860,19 @@ p {
 }
 
 .high {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/expression/high.gif);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/expression/high.gif);
 }
 
 .low {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/expression/low.gif);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/expression/low.gif);
 }
 
 .middle {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/expression/middle.gif);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/expression/middle.gif);
 }
 
 .super {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/expression/super.gif);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/expression/super.gif);
 }
 
 ul li {
@@ -1908,27 +1908,27 @@ ul li {
 }
 
 #pagenum-1 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/left.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/left.png);
 }
 
 #pagenum-2 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/right.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/right.png);
 }
 
 #pagenum-5 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/leftPage.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/leftPage.png);
 }
 
 #pagenum-6 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/rightPage.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/achievement/rightPage.png);
 }
 
 #pagenum-7 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/left.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/left.png);
 }
 
 #pagenum-8 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/right.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/ui/right.png);
 }
 
 .cg-frame {
@@ -1950,7 +1950,7 @@ ul li {
   background-size: auto 88%;
   background-position: center;
   display: inline-block;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/common/cgclose.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/common/cgclose.png);
 }
 
 .showCgOrigin {

--- a/public/novels/ae/ko-KR/game.js
+++ b/public/novels/ae/ko-KR/game.js
@@ -1,4 +1,4 @@
-var base_url = 'https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy'
+var base_url = 'https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy'
 var extra_url = '/novels/ae/ko-KR/extra'
 base_url = resPath
 var now_galgame_tag = '_2017_anti_entropy_now_galgame'

--- a/public/novels/ae/ko-KR/index.html
+++ b/public/novels/ae/ko-KR/index.html
@@ -19,12 +19,12 @@
       content="black-translucent"
     />
     <link
-      href="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/css/common.css?v=20210817"
+      href="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/css/common.css?v=20210817"
       rel="stylesheet"
       type="text/css"
     />
     <link
-      href="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/css/css3_animation.css?v=20210817"
+      href="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/css/css3_animation.css?v=20210817"
       rel="stylesheet"
       type="text/css"
     />
@@ -65,14 +65,14 @@
     <div class="wrk">
       <img
         class="wrk-i"
-        src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/common/horizon_hint.png"
+        src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/common/horizon_hint.png"
       />
     </div>
     <table id="loading">
       <tr>
         <td>
           <img
-            src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/common/loading.gif"
+            src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/common/loading.gif"
           />
         </td>
       </tr>
@@ -83,7 +83,7 @@
         <audio
           class="bgm"
           id="indexbgm"
-          src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/sound/themeEin.mp3"
+          src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/sound/themeEin.mp3"
           loop="loop"
           controls="controls"
         ></audio>
@@ -267,25 +267,25 @@
     </div>
     <script>
       var cssPath =
-        'https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN'
+        'https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN'
       var jsPath =
-        'https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN'
+        'https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN'
       var resPath =
-        'https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN'
+        'https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN'
       var xmlPath = '/novels/ae/ko-KR/xml/'
       var lang = 'ko'
     </script>
     <script
       type="text/javascript"
-      src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/tips/game_tips.js?v=20210817"
+      src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/tips/game_tips.js?v=20210817"
     ></script>
     <script
       type="text/javascript"
-      src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/js/jquery-1.11.1.min.js?v=20210817"
+      src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/js/jquery-1.11.1.min.js?v=20210817"
     ></script>
     <script
       type="text/javascript"
-      src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/js/xmlhttp.js?v=20210817"
+      src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/js/xmlhttp.js?v=20210817"
     ></script>
     <script type="text/javascript" src="/novels/ae/ko-KR/game.js?v=20210817"></script>
   </body>

--- a/public/novels/duriduri/en-US/gameDurandal.css
+++ b/public/novels/duriduri/en-US/gameDurandal.css
@@ -106,7 +106,7 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/background/bg.jpg)
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/background/bg.jpg)
     center / auto 100% no-repeat;
   z-index: 520;
   display: none;
@@ -118,7 +118,7 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/background/CG1.jpg)
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/background/CG1.jpg)
     center / auto 100% no-repeat;
   z-index: 520;
   display: none;
@@ -130,27 +130,27 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/dark.png)
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/dark.png)
     center / auto 100% no-repeat;
 }
 
 .catalog-content-1A {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/A.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/A.png);
 }
 .catalog-content-2Ab {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/Ab.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/Ab.png);
 }
 .catalog-content-3Abc {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/Abc.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/Abc.png);
 }
 .catalog-content-2Ba {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/Ba.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/Ba.png);
 }
 .catalog-content-3Bac {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/Bac.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/Bac.png);
 }
 .catalog-content-3Cab {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/Cab.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/Cab.png);
 }
 
 #catalog-content-0 {
@@ -182,7 +182,7 @@ p {
   top: 6rem;
   height: 2rem;
   right: 3rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/go.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/go.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -218,7 +218,7 @@ p {
   top: 1.35rem;
   height: 1.5rem;
   left: 7.75rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_1_on.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_1_on.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -230,7 +230,7 @@ p {
   top: 1.35rem;
   height: 1.5rem;
   left: 7.75rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_1_off.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_1_off.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -243,7 +243,7 @@ p {
   top: 1.35rem;
   height: 1.5rem;
   left: 14.3rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_2_on.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_2_on.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -255,7 +255,7 @@ p {
   top: 1.35rem;
   height: 1.5rem;
   left: 14.3rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_2_off.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_2_off.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -268,7 +268,7 @@ p {
   top: 1.35rem;
   height: 1.5rem;
   left: 20.85rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_3_on.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_3_on.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -280,7 +280,7 @@ p {
   top: 1.35rem;
   height: 1.5rem;
   left: 20.85rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_3_off.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_3_off.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -293,7 +293,7 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/portraitBg.jpg)
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/portraitBg.jpg)
     center / auto 100% no-repeat;
   z-index: 520;
   display: none;
@@ -305,7 +305,7 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/listBG.jpg)
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/listBG.jpg)
     center / auto 100% no-repeat;
   z-index: 1200;
   display: none;
@@ -317,7 +317,7 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/background/bg.jpg)
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/background/bg.jpg)
     center / auto 100% no-repeat;
   z-index: 1300;
   display: none;
@@ -348,7 +348,7 @@ p {
   width: 28.55rem;
   left: 0;
   bottom: 0;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/barBottom.png);
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/barBottom.png);
   background-size: 28.55rem 2.1rem;
   background-position: left;
   background-repeat: no-repeat;
@@ -372,7 +372,7 @@ p {
   height: 2.1rem;
   left: 0;
   bottom: 0;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/barTop.png);
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/barTop.png);
   background-size: 28.55rem 2.1rem;
   background-position: left;
   background-repeat: no-repeat;
@@ -385,7 +385,7 @@ p {
   bottom: -1.75rem;
   height: 4.5rem;
   width: 39.1rem;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/barFrame.png);
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/barFrame.png);
   background-size: 39.1rem 4.5rem;
   background-position: left;
   background-repeat: no-repeat;
@@ -398,7 +398,7 @@ p {
   width: 2.6rem;
   left: 0;
   bottom: -0.375rem;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/barIcon.png);
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/barIcon.png);
   background-size: 2.6rem 2.85rem;
   background-position: left;
   background-repeat: no-repeat;
@@ -412,7 +412,7 @@ p {
   width: 5.9rem;
   right: 0.75rem;
   bottom: 0.65rem;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/details.png)
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/details.png)
     center / auto 100% no-repeat;
   cursor: pointer;
 }
@@ -566,7 +566,7 @@ p {
   height: 50%;
   top: 10%;
   left: 25%;
-  background: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/common/horizon_hint.png')
+  background: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/common/horizon_hint.png')
     100% 100% /100% auto no-repeat;
 }
 #confirm {
@@ -668,7 +668,7 @@ p {
   top: 0;
   right: 0;
   z-index: 810;
-  background: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/close.png');
+  background: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/close.png');
   background-size: 100% 100%;
   background-position: center;
   cursor: pointer;
@@ -696,7 +696,7 @@ p {
   bottom: 6rem;
   right: 0;
   z-index: 810;
-  background: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/remark.png');
+  background: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/remark.png');
   background-size: 100% 100%;
   background-position: center;
 }
@@ -709,7 +709,7 @@ p {
   top: 0;
   right: 0;
   z-index: 810;
-  background: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/close.png');
+  background: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/close.png');
   background-size: 100% 100%;
   background-position: center;
   cursor: pointer;
@@ -723,7 +723,7 @@ p {
   top: 0;
   right: 0;
   z-index: 810;
-  background: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/exit.png');
+  background: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/exit.png');
   background-size: 100% 100%;
   background-position: center;
   cursor: pointer;
@@ -746,7 +746,7 @@ p {
   top: 0;
   left: 0;
   z-index: 810;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/save.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/save.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -760,7 +760,7 @@ p {
   top: 0;
   left: 6.4rem;
   z-index: 810;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/load.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/load.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -782,7 +782,7 @@ p {
   height: 100%;
   bottom: 0;
   left: 6.4rem;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/auto.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/auto.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -790,7 +790,7 @@ p {
 }
 
 .dialog-btn-autoplay-on {
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/auto_1.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/auto_1.png');
 }
 
 .dialog-btn-history {
@@ -799,7 +799,7 @@ p {
   height: 100%;
   top: 0;
   right: 0;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/log.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/log.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -812,7 +812,7 @@ p {
   height: 100%;
   top: 0;
   left: 0;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/skip.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/skip.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -820,7 +820,7 @@ p {
 }
 
 .dialog-btn-skip-on {
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/skip_1.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/skip_1.png');
 }
 
 .menuscene {
@@ -839,7 +839,7 @@ p {
   width: 100%;
   height: 100%;
   z-index: 0;
-  background: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/menu/fg.png');
+  background: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/menu/fg.png');
   background-size: auto 100%;
 }
 
@@ -878,7 +878,7 @@ p {
   background-image: url('/novels/duriduri/en-US/history.png');
 }
 .menu_btn_4 {
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/menu/achievement.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/menu/achievement.png');
 }
 
 #loading {
@@ -1366,7 +1366,7 @@ p {
   width: /*90%*/ 42rem;
   height: /*25%*/ 7rem;
   z-index: 210;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/dialog.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/dialog.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -1377,7 +1377,7 @@ p {
 
 .dialog_article {
   height: 21rem;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/dialogBig.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/dialogBig.png');
 }
 
 .history {
@@ -1387,7 +1387,7 @@ p {
   width: 42rem;
   height: 21rem;
   z-index: 250;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/dialogBig.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/dialogBig.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -1402,7 +1402,7 @@ p {
   width: 42rem;
   height: 21rem;
   z-index: 250;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/dialogBig.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/dialogBig.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -1544,15 +1544,15 @@ p {
 
 .dialog-chara-line.dialog-chara-left {
   width: 1.14rem;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/Label-L.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/Label-L.png');
 }
 .dialog-chara-line.dialog-chara-center {
   background-repeat: repeat;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/Label-M.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/Label-M.png');
 }
 .dialog-chara-line.dialog-chara-right {
   width: 2.4rem;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/Label-R.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/Label-R.png');
 }
 
 .dialog-chara-padding {
@@ -1738,16 +1738,16 @@ p {
 }
 
 .high {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/expression/high.gif);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/expression/high.gif);
 }
 .low {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/expression/low.gif);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/expression/low.gif);
 }
 .middle {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/expression/middle.gif);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/expression/middle.gif);
 }
 .super {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/expression/super.gif);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/expression/super.gif);
 }
 
 ul li {
@@ -1783,23 +1783,23 @@ ul li {
 }
 
 #pagenum-1 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/left.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/left.png);
 }
 #pagenum-2 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/right.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/right.png);
 }
 
 #pagenum-5 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/leftPage.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/leftPage.png);
 }
 #pagenum-6 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/rightPage.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/rightPage.png);
 }
 #pagenum-7 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/left.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/left.png);
 }
 #pagenum-8 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/right.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/right.png);
 }
 
 .cg-frame {
@@ -1820,7 +1820,7 @@ ul li {
   background-size: auto 88%;
   background-position: center;
   display: inline-block;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/common/cgclose.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/common/cgclose.png);
 }
 
 .showCgOrigin {

--- a/public/novels/duriduri/en-US/index.html
+++ b/public/novels/duriduri/en-US/index.html
@@ -19,12 +19,12 @@
       content="black-translucent"
     />
     <link
-      href="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/css/common.css?v=20190203"
+      href="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/css/common.css?v=20190203"
       rel="stylesheet"
       type="text/css"
     />
     <link
-      href="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/css/css3_animation.css?v=20190203"
+      href="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/css/css3_animation.css?v=20190203"
       rel="stylesheet"
       type="text/css"
     />
@@ -61,7 +61,7 @@
   </head>
   <body>
     <iframe
-      src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/sound/01_21_1-second-of-silence.mp3"
+      src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/sound/01_21_1-second-of-silence.mp3"
       allow="autoplay"
       id="audio"
       style="display: none"
@@ -69,14 +69,14 @@
     <div class="wrk">
       <img
         class="wrk-i"
-        src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/common/horizon_hint.png"
+        src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/common/horizon_hint.png"
       />
     </div>
     <table id="loading">
       <tr>
         <td>
           <img
-            src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/common/loading.gif"
+            src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/common/loading.gif"
           />
         </td>
       </tr>
@@ -87,7 +87,7 @@
         <audio
           class="bgm"
           id="indexbgm"
-          src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/sound/theme.mp3"
+          src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/sound/theme.mp3"
           loop="loop"
           controls="controls"
         ></audio>
@@ -307,25 +307,25 @@
     </div>
     <script>
       var cssPath =
-        'https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN'
+        'https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN'
       var jsPath =
-        'https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN'
+        'https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN'
       var resPath =
-        'https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN'
+        'https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN'
       var xmlPath = '/novels/duriduri/en-US/xmlDurandal/'
       var lang = 'en-US'
     </script>
     <script
       type="text/javascript"
-      src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/tips/game_tips.js?v=20190203"
+      src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/tips/game_tips.js?v=20190203"
     ></script>
     <script
       type="text/javascript"
-      src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/js/jquery-1.11.1.min.js?v=20190203"
+      src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/js/jquery-1.11.1.min.js?v=20190203"
     ></script>
     <script
       type="text/javascript"
-      src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/js/xmlhttp.js?v=20190203"
+      src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/js/xmlhttp.js?v=20190203"
     ></script>
     <script
       type="text/javascript"

--- a/public/novels/duriduri/ko-KR/gameDurandal.css
+++ b/public/novels/duriduri/ko-KR/gameDurandal.css
@@ -106,7 +106,7 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/background/bg.jpg)
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/background/bg.jpg)
     center / auto 100% no-repeat;
   z-index: 520;
   display: none;
@@ -118,7 +118,7 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/background/CG1.jpg)
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/background/CG1.jpg)
     center / auto 100% no-repeat;
   z-index: 520;
   display: none;
@@ -130,27 +130,27 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/dark.png)
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/dark.png)
     center / auto 100% no-repeat;
 }
 
 .catalog-content-1A {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/A.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/A.png);
 }
 .catalog-content-2Ab {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/Ab.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/Ab.png);
 }
 .catalog-content-3Abc {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/Abc.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/Abc.png);
 }
 .catalog-content-2Ba {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/Ba.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/Ba.png);
 }
 .catalog-content-3Bac {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/Bac.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/Bac.png);
 }
 .catalog-content-3Cab {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/Cab.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/Cab.png);
 }
 
 #catalog-content-0 {
@@ -182,7 +182,7 @@ p {
   top: 6rem;
   height: 2rem;
   right: 3rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/go.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/go.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -219,7 +219,7 @@ p {
   top: 1.35rem;
   height: 1.5rem;
   left: 7.75rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_1_on.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_1_on.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -231,7 +231,7 @@ p {
   top: 1.35rem;
   height: 1.5rem;
   left: 7.75rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_1_off.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_1_off.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -244,7 +244,7 @@ p {
   top: 1.35rem;
   height: 1.5rem;
   left: 14.3rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_2_on.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_2_on.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -256,7 +256,7 @@ p {
   top: 1.35rem;
   height: 1.5rem;
   left: 14.3rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_2_off.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_2_off.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -269,7 +269,7 @@ p {
   top: 1.35rem;
   height: 1.5rem;
   left: 20.85rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_3_on.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_3_on.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -281,7 +281,7 @@ p {
   top: 1.35rem;
   height: 1.5rem;
   left: 20.85rem;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_3_off.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/catalog/label_3_off.png);
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;
@@ -294,7 +294,7 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/portraitBg.jpg)
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/portraitBg.jpg)
     center / auto 100% no-repeat;
   z-index: 520;
   display: none;
@@ -306,7 +306,7 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/listBG.jpg)
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/listBG.jpg)
     center / auto 100% no-repeat;
   z-index: 1200;
   display: none;
@@ -318,7 +318,7 @@ p {
   height: 100%;
   top: 0px;
   left: 0px;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/background/bg.jpg)
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/background/bg.jpg)
     center / auto 100% no-repeat;
   z-index: 1300;
   display: none;
@@ -349,7 +349,7 @@ p {
   width: 28.55rem;
   left: 0;
   bottom: 0;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/barBottom.png);
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/barBottom.png);
   background-size: 28.55rem 2.1rem;
   background-position: left;
   background-repeat: no-repeat;
@@ -373,7 +373,7 @@ p {
   height: 2.1rem;
   left: 0;
   bottom: 0;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/barTop.png);
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/barTop.png);
   background-size: 28.55rem 2.1rem;
   background-position: left;
   background-repeat: no-repeat;
@@ -386,7 +386,7 @@ p {
   bottom: -1.75rem;
   height: 4.5rem;
   width: 39.1rem;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/barFrame.png);
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/barFrame.png);
   background-size: 39.1rem 4.5rem;
   background-position: left;
   background-repeat: no-repeat;
@@ -399,7 +399,7 @@ p {
   width: 2.6rem;
   left: 0;
   bottom: -0.375rem;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/barIcon.png);
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/barIcon.png);
   background-size: 2.6rem 2.85rem;
   background-position: left;
   background-repeat: no-repeat;
@@ -413,7 +413,7 @@ p {
   width: 5.9rem;
   right: 0.75rem;
   bottom: 0.65rem;
-  background: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/details.png)
+  background: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/details.png)
     center / auto 100% no-repeat;
   cursor: pointer;
 }
@@ -567,7 +567,7 @@ p {
   height: 50%;
   top: 10%;
   left: 25%;
-  background: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/common/horizon_hint.png')
+  background: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/common/horizon_hint.png')
     100% 100% /100% auto no-repeat;
 }
 #confirm {
@@ -669,7 +669,7 @@ p {
   top: 0;
   right: 0;
   z-index: 810;
-  background: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/close.png');
+  background: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/close.png');
   background-size: 100% 100%;
   background-position: center;
   cursor: pointer;
@@ -697,7 +697,7 @@ p {
   bottom: 6rem;
   right: 0;
   z-index: 810;
-  background: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/remark.png');
+  background: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/remark.png');
   background-size: 100% 100%;
   background-position: center;
 }
@@ -710,7 +710,7 @@ p {
   top: 0;
   right: 0;
   z-index: 810;
-  background: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/close.png');
+  background: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/close.png');
   background-size: 100% 100%;
   background-position: center;
   cursor: pointer;
@@ -724,7 +724,7 @@ p {
   top: 0;
   right: 0;
   z-index: 810;
-  background: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/exit.png');
+  background: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/exit.png');
   background-size: 100% 100%;
   background-position: center;
   cursor: pointer;
@@ -747,7 +747,7 @@ p {
   top: 0;
   left: 0;
   z-index: 810;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/save.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/save.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -761,7 +761,7 @@ p {
   top: 0;
   left: 6.4rem;
   z-index: 810;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/load.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/load.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -783,7 +783,7 @@ p {
   height: 100%;
   bottom: 0;
   left: 6.4rem;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/auto.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/auto.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -791,7 +791,7 @@ p {
 }
 
 .dialog-btn-autoplay-on {
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/auto_1.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/auto_1.png');
 }
 
 .dialog-btn-history {
@@ -800,7 +800,7 @@ p {
   height: 100%;
   top: 0;
   right: 0;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/log.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/log.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -813,7 +813,7 @@ p {
   height: 100%;
   top: 0;
   left: 0;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/skip.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/skip.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -821,7 +821,7 @@ p {
 }
 
 .dialog-btn-skip-on {
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/skip_1.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/skip_1.png');
 }
 
 .menuscene {
@@ -840,7 +840,7 @@ p {
   width: 100%;
   height: 100%;
   z-index: 0;
-  background: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/menu/fg.png');
+  background: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/menu/fg.png');
   background-size: auto 100%;
 }
 
@@ -1364,7 +1364,7 @@ p {
   width: /*90%*/ 42rem;
   height: /*25%*/ 7rem;
   z-index: 210;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/dialog.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/dialog.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -1375,7 +1375,7 @@ p {
 
 .dialog_article {
   height: 21rem;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/dialogBig.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/dialogBig.png');
 }
 
 .history {
@@ -1385,7 +1385,7 @@ p {
   width: 42rem;
   height: 21rem;
   z-index: 250;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/dialogBig.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/dialogBig.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -1400,7 +1400,7 @@ p {
   width: 42rem;
   height: 21rem;
   z-index: 250;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/dialogBig.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/dialogBig.png');
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -1542,15 +1542,15 @@ p {
 
 .dialog-chara-line.dialog-chara-left {
   width: 1.14rem;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/Label-L.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/Label-L.png');
 }
 .dialog-chara-line.dialog-chara-center {
   background-repeat: repeat;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/Label-M.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/Label-M.png');
 }
 .dialog-chara-line.dialog-chara-right {
   width: 2.4rem;
-  background-image: url('https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/Label-R.png');
+  background-image: url('https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/Label-R.png');
 }
 
 .dialog-chara-padding {
@@ -1736,16 +1736,16 @@ p {
 }
 
 .high {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/expression/high.gif);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/expression/high.gif);
 }
 .low {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/expression/low.gif);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/expression/low.gif);
 }
 .middle {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/expression/middle.gif);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/expression/middle.gif);
 }
 .super {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/expression/super.gif);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/expression/super.gif);
 }
 
 ul li {
@@ -1781,23 +1781,23 @@ ul li {
 }
 
 #pagenum-1 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/left.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/left.png);
 }
 #pagenum-2 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/right.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/right.png);
 }
 
 #pagenum-5 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/leftPage.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/leftPage.png);
 }
 #pagenum-6 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/rightPage.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/achievement/rightPage.png);
 }
 #pagenum-7 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/left.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/left.png);
 }
 #pagenum-8 {
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/right.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/ui/right.png);
 }
 
 .cg-frame {
@@ -1818,7 +1818,7 @@ ul li {
   background-size: auto 88%;
   background-position: center;
   display: inline-block;
-  background-image: url(https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/common/cgclose.png);
+  background-image: url(https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/common/cgclose.png);
 }
 
 .showCgOrigin {

--- a/public/novels/duriduri/ko-KR/index.html
+++ b/public/novels/duriduri/ko-KR/index.html
@@ -19,12 +19,12 @@
       content="black-translucent"
     />
     <link
-      href="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/css/common.css?v=20190203"
+      href="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/css/common.css?v=20190203"
       rel="stylesheet"
       type="text/css"
     />
     <link
-      href="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/css/css3_animation.css?v=20190203"
+      href="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/css/css3_animation.css?v=20190203"
       rel="stylesheet"
       type="text/css"
     />
@@ -60,7 +60,7 @@
   </head>
   <body>
     <iframe
-      src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/sound/01_21_1-second-of-silence.mp3"
+      src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/sound/01_21_1-second-of-silence.mp3"
       allow="autoplay"
       id="audio"
       style="display: none"
@@ -68,14 +68,14 @@
     <div class="wrk">
       <img
         class="wrk-i"
-        src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/common/horizon_hint.png"
+        src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/common/horizon_hint.png"
       />
     </div>
     <table id="loading">
       <tr>
         <td>
           <img
-            src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/resources/common/loading.gif"
+            src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/resources/common/loading.gif"
           />
         </td>
       </tr>
@@ -86,7 +86,7 @@
         <audio
           class="bgm"
           id="indexbgm"
-          src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/sound/theme.mp3"
+          src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/baseDurandal/resources/sound/theme.mp3"
           loop="loop"
           controls="controls"
         ></audio>
@@ -306,25 +306,25 @@
     </div>
     <script>
       var cssPath =
-        'https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN'
+        'https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN'
       var jsPath =
-        'https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN'
+        'https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN'
       var resPath =
-        'https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN'
+        'https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN'
       var xmlPath = '/novels/duriduri/ko-KR/xmlDurandal/'
       var lang = 'ko-KR'
     </script>
     <script
       type="text/javascript"
-      src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/tips/game_tips.js?v=20190203"
+      src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/tips/game_tips.js?v=20190203"
     ></script>
     <script
       type="text/javascript"
-      src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/js/jquery-1.11.1.min.js?v=20190203"
+      src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/js/jquery-1.11.1.min.js?v=20190203"
     ></script>
     <script
       type="text/javascript"
-      src="https://webstatic.bh3.com/event_bh3_com/avg-anti-entropy/static_CN/js/xmlhttp.js?v=20190203"
+      src="https://act-webstatic.mihoyo.com/event_bh3_com/avg-anti-entropy/static_CN/js/xmlhttp.js?v=20190203"
     ></script>
     <script
       type="text/javascript"


### PR DESCRIPTION
Changed the domain for resources from `webstatic.bh3.com` (which doesn't exist anymore) to `act-webstatic.mihoyo.com` (which is currently used in the CN VNs) to fix the VNs.